### PR TITLE
Replace `fregante/setup-git-token` with `setup-git-user`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,9 +10,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: setup git token
-        uses: fregante/setup-git-token@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: fregante/setup-git-user@v1
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Thanks to `actions/checkout@v2`, setting the token is no longer necessary, so I created a new config-less action to just set the git user: https://github.com/fregante/setup-git-user