### PR TITLE
Add initial component and container to view mock iTunes tracks

### DIFF
--- a/app/components/ItunesTracks/index.js
+++ b/app/components/ItunesTracks/index.js
@@ -1,0 +1,47 @@
+/**
+ *
+ * ItunesTracks
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const TrackCard = styled.div`
+  padding: 20px;
+  margin: 1px solid black;
+  display: flex;
+`;
+
+const TrackImg = styled.div`
+  width: 50%;
+  overflow: hidden;
+`;
+
+const TrackInfo = styled.div`
+  align-self: flex-center;
+`;
+
+export function ItunesTracks({ artistName, trackName, artworkUrl }) {
+  return (
+    <TrackCard data-testid="itunes-tracks">
+      <TrackImg>
+        <img src={artworkUrl} alt={artistName} />
+      </TrackImg>
+      <TrackInfo>
+        Artist Name - {artistName}
+        <br />
+        Track Name - {trackName}
+      </TrackInfo>
+    </TrackCard>
+  );
+}
+
+ItunesTracks.propTypes = {
+  artistName: PropTypes.string,
+  trackName: PropTypes.string,
+  artworkUrl: PropTypes.string
+};
+
+export default ItunesTracks;

--- a/app/components/ItunesTracks/tests/index.test.js
+++ b/app/components/ItunesTracks/tests/index.test.js
@@ -1,0 +1,28 @@
+/**
+ *
+ * Tests for ItunesTracks
+ *
+ */
+
+import React from 'react';
+// import { fireEvent } from '@testing-library/dom'
+import { renderWithIntl } from '@utils/testUtils';
+import ItunesTracks from '../index';
+
+describe('<ItunesTracks />', () => {
+  it('should render and match the snapshot', () => {
+    const { baseElement } = renderWithIntl(<ItunesTracks />);
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  it('should contain 1 ItunesTracks component', () => {
+    const { getAllByTestId } = renderWithIntl(
+      <ItunesTracks
+        artistName="Jack Johnson"
+        trackName="Jack Johnson"
+        artworkUrl="https://is3-ssl.mzstatic.com/image/thumb/Music115/v4/08/11/d2/0811d2b3-b4d5-dc22-1107-3625511844b5/00602537869770.rgb.jpg/100x100bb.jpg"
+      />
+    );
+    expect(getAllByTestId('itunes-tracks').length).toBe(1);
+  });
+});

--- a/app/containers/ItunesContainer/Loadable.js
+++ b/app/containers/ItunesContainer/Loadable.js
@@ -1,0 +1,3 @@
+import loadable from '@utils/loadable';
+
+export default loadable(() => import('./index'));

--- a/app/containers/ItunesContainer/index.js
+++ b/app/containers/ItunesContainer/index.js
@@ -1,0 +1,231 @@
+/**
+ *
+ * ItunesContainer Container
+ *
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { injectIntl, FormattedMessage as T } from 'react-intl';
+
+import { createStructuredSelector } from 'reselect';
+import { compose } from 'redux';
+import { injectSaga } from 'redux-injectors';
+import { selectSomePayLoad } from './selectors';
+import ItunesTracks from '@components/ItunesTracks';
+import saga from './saga';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 600px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 20px;
+`;
+
+const StyledT = styled(T)`
+  font-weight: 10px;
+  text-transform: uppercase;
+`;
+
+const itunesTracks = {
+  resultCount: 4,
+  results: [
+    {
+      wrapperType: 'track',
+      kind: 'song',
+      artistId: 909253,
+      collectionId: 1469577723,
+      trackId: 1469577741,
+      artistName: 'Jack Johnson',
+      collectionName: 'Jack Johnson and Friends: Sing-A-Longs and Lullabies for the Film Curious George',
+      trackName: 'Upside Down',
+      collectionCensoredName: 'Jack Johnson and Friends: Sing-A-Longs and Lullabies for the Film Curious George',
+      trackCensoredName: 'Upside Down',
+      artistViewUrl: 'https://music.apple.com/us/artist/jack-johnson/909253?uo=4',
+      collectionViewUrl: 'https://music.apple.com/us/album/upside-down/1469577723?i=1469577741&uo=4',
+      trackViewUrl: 'https://music.apple.com/us/album/upside-down/1469577723?i=1469577741&uo=4',
+      previewUrl:
+        'https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview125/v4/5e/5b/3d/5e5b3df4-deb5-da78-5d64-fe51d8404d5c/mzaf_13341178261601361485.plus.aac.p.m4a',
+      artworkUrl30:
+        'https://is3-ssl.mzstatic.com/image/thumb/Music115/v4/08/11/d2/0811d2b3-b4d5-dc22-1107-3625511844b5/00602537869770.rgb.jpg/30x30bb.jpg',
+      artworkUrl60:
+        'https://is3-ssl.mzstatic.com/image/thumb/Music115/v4/08/11/d2/0811d2b3-b4d5-dc22-1107-3625511844b5/00602537869770.rgb.jpg/60x60bb.jpg',
+      artworkUrl100:
+        'https://is3-ssl.mzstatic.com/image/thumb/Music115/v4/08/11/d2/0811d2b3-b4d5-dc22-1107-3625511844b5/00602537869770.rgb.jpg/100x100bb.jpg',
+      collectionPrice: 9.99,
+      trackPrice: 1.29,
+      releaseDate: '2005-01-01T12:00:00Z',
+      collectionExplicitness: 'notExplicit',
+      trackExplicitness: 'notExplicit',
+      discCount: 1,
+      discNumber: 1,
+      trackCount: 14,
+      trackNumber: 1,
+      trackTimeMillis: 208643,
+      country: 'USA',
+      currency: 'USD',
+      primaryGenreName: 'Rock',
+      isStreamable: true
+    },
+    {
+      wrapperType: 'track',
+      kind: 'song',
+      artistId: 909253,
+      collectionId: 1469577723,
+      trackId: 1469577830,
+      artistName: 'Jack Johnson',
+      collectionName: 'Jack Johnson and Friends: Sing-A-Longs and Lullabies for the Film Curious George',
+      trackName: "We're Going To Be Friends",
+      collectionCensoredName: 'Jack Johnson and Friends: Sing-A-Longs and Lullabies for the Film Curious George',
+      trackCensoredName: "We're Going To Be Friends",
+      artistViewUrl: 'https://music.apple.com/us/artist/jack-johnson/909253?uo=4',
+      collectionViewUrl: 'https://music.apple.com/us/album/were-going-to-be-friends/1469577723?i=1469577830&uo=4',
+      trackViewUrl: 'https://music.apple.com/us/album/were-going-to-be-friends/1469577723?i=1469577830&uo=4',
+      previewUrl:
+        'https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview125/v4/ce/48/5b/ce485b59-13b7-9859-0431-e602d6347479/mzaf_7168871676263777717.plus.aac.p.m4a',
+      artworkUrl30:
+        'https://is3-ssl.mzstatic.com/image/thumb/Music115/v4/08/11/d2/0811d2b3-b4d5-dc22-1107-3625511844b5/00602537869770.rgb.jpg/30x30bb.jpg',
+      artworkUrl60:
+        'https://is3-ssl.mzstatic.com/image/thumb/Music115/v4/08/11/d2/0811d2b3-b4d5-dc22-1107-3625511844b5/00602537869770.rgb.jpg/60x60bb.jpg',
+      artworkUrl100:
+        'https://is3-ssl.mzstatic.com/image/thumb/Music115/v4/08/11/d2/0811d2b3-b4d5-dc22-1107-3625511844b5/00602537869770.rgb.jpg/100x100bb.jpg',
+      collectionPrice: 9.99,
+      trackPrice: 1.29,
+      releaseDate: '2005-01-01T12:00:00Z',
+      collectionExplicitness: 'notExplicit',
+      trackExplicitness: 'notExplicit',
+      discCount: 1,
+      discNumber: 1,
+      trackCount: 14,
+      trackNumber: 7,
+      trackTimeMillis: 137533,
+      country: 'USA',
+      currency: 'USD',
+      primaryGenreName: 'Rock',
+      isStreamable: true
+    },
+    {
+      wrapperType: 'track',
+      kind: 'song',
+      artistId: 909253,
+      collectionId: 1469577723,
+      trackId: 1469577808,
+      artistName: 'Jack Johnson',
+      collectionName: 'Jack Johnson and Friends: Sing-A-Longs and Lullabies for the Film Curious George',
+      trackName: 'Broken',
+      collectionCensoredName: 'Jack Johnson and Friends: Sing-A-Longs and Lullabies for the Film Curious George',
+      trackCensoredName: 'Broken',
+      artistViewUrl: 'https://music.apple.com/us/artist/jack-johnson/909253?uo=4',
+      collectionViewUrl: 'https://music.apple.com/us/album/broken/1469577723?i=1469577808&uo=4',
+      trackViewUrl: 'https://music.apple.com/us/album/broken/1469577723?i=1469577808&uo=4',
+      previewUrl:
+        'https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview115/v4/8b/fd/81/8bfd81a6-0217-b56c-01b0-7249ed910a35/mzaf_16218415284344588014.plus.aac.p.m4a',
+      artworkUrl30:
+        'https://is3-ssl.mzstatic.com/image/thumb/Music115/v4/08/11/d2/0811d2b3-b4d5-dc22-1107-3625511844b5/00602537869770.rgb.jpg/30x30bb.jpg',
+      artworkUrl60:
+        'https://is3-ssl.mzstatic.com/image/thumb/Music115/v4/08/11/d2/0811d2b3-b4d5-dc22-1107-3625511844b5/00602537869770.rgb.jpg/60x60bb.jpg',
+      artworkUrl100:
+        'https://is3-ssl.mzstatic.com/image/thumb/Music115/v4/08/11/d2/0811d2b3-b4d5-dc22-1107-3625511844b5/00602537869770.rgb.jpg/100x100bb.jpg',
+      collectionPrice: 9.99,
+      trackPrice: 1.29,
+      releaseDate: '2006-02-07T12:00:00Z',
+      collectionExplicitness: 'notExplicit',
+      trackExplicitness: 'notExplicit',
+      discCount: 1,
+      discNumber: 1,
+      trackCount: 14,
+      trackNumber: 2,
+      trackTimeMillis: 234746,
+      country: 'USA',
+      currency: 'USD',
+      primaryGenreName: 'Rock',
+      isStreamable: true
+    },
+    {
+      wrapperType: 'track',
+      kind: 'song',
+      artistId: 41742672,
+      collectionId: 263301268,
+      trackId: 263301273,
+      artistName: 'This Bike Is a Pipe Bomb',
+      collectionName: 'Three Way Tie for a Fifth',
+      trackName: 'Jack Johnson',
+      collectionCensoredName: 'Three Way Tie for a Fifth',
+      trackCensoredName: 'Jack Johnson',
+      artistViewUrl: 'https://music.apple.com/us/artist/this-bike-is-a-pipe-bomb/41742672?uo=4',
+      collectionViewUrl: 'https://music.apple.com/us/album/jack-johnson/263301268?i=263301273&uo=4',
+      trackViewUrl: 'https://music.apple.com/us/album/jack-johnson/263301268?i=263301273&uo=4',
+      previewUrl:
+        'https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview125/v4/fd/bb/38/fdbb38d2-073d-4bc7-68c4-348a0be6d560/mzaf_4150435585996894188.plus.aac.p.m4a',
+      artworkUrl30:
+        'https://is4-ssl.mzstatic.com/image/thumb/Music124/v4/f3/ee/b3/f3eeb3ff-ca32-273a-15aa-709bdfa64367/mzi.izwiyqez.jpg/30x30bb.jpg',
+      artworkUrl60:
+        'https://is4-ssl.mzstatic.com/image/thumb/Music124/v4/f3/ee/b3/f3eeb3ff-ca32-273a-15aa-709bdfa64367/mzi.izwiyqez.jpg/60x60bb.jpg',
+      artworkUrl100:
+        'https://is4-ssl.mzstatic.com/image/thumb/Music124/v4/f3/ee/b3/f3eeb3ff-ca32-273a-15aa-709bdfa64367/mzi.izwiyqez.jpg/100x100bb.jpg',
+      collectionPrice: 9.99,
+      trackPrice: 0.99,
+      releaseDate: '2004-06-15T12:00:00Z',
+      collectionExplicitness: 'notExplicit',
+      trackExplicitness: 'notExplicit',
+      discCount: 1,
+      discNumber: 1,
+      trackCount: 11,
+      trackNumber: 1,
+      trackTimeMillis: 117573,
+      country: 'USA',
+      currency: 'USD',
+      primaryGenreName: 'Alternative',
+      isStreamable: true
+    }
+  ]
+};
+
+const renderItunes = () => {
+  return (
+    <>
+      {itunesTracks.resultCount > 0 &&
+        itunesTracks.results.map((item, index) => (
+          <ItunesTracks
+            key={index}
+            artistName={item.artistName}
+            trackName={item.trackName}
+            artworkUrl={item.artworkUrl100}
+          />
+        ))}
+    </>
+  );
+};
+
+export function ItunesContainer() {
+  return (
+    <Container>
+      <StyledT id={'Itunes Tracks'} />
+      {renderItunes()}
+    </Container>
+  );
+}
+
+ItunesContainer.propTypes = {
+  somePayLoad: PropTypes.any
+};
+
+const mapStateToProps = createStructuredSelector({
+  somePayLoad: selectSomePayLoad()
+});
+
+function mapDispatchToProps(dispatch) {
+  return {
+    dispatch
+  };
+}
+
+const withConnect = connect(mapStateToProps, mapDispatchToProps);
+
+export default compose(withConnect, injectSaga({ key: 'itunesContainer', saga }))(ItunesContainer);
+
+export const ItunesContainerTest = compose(injectIntl)(ItunesContainer);

--- a/app/containers/ItunesContainer/reducer.js
+++ b/app/containers/ItunesContainer/reducer.js
@@ -1,0 +1,27 @@
+/*
+ *
+ * ItunesContainer reducer
+ *
+ */
+import produce from 'immer';
+import { createActions } from 'reduxsauce';
+
+export const initialState = {
+  somePayLoad: null
+};
+
+export const { Types: itunesContainerTypes, Creators: itunesContainerCreators } = createActions({
+  defaultAction: ['somePayLoad']
+});
+
+export const itunesContainerReducer = (state = initialState, action) =>
+  produce(state, (draft) => {
+    switch (action.type) {
+      case itunesContainerTypes.DEFAULT_ACTION:
+        draft.somePayLoad = action.somePayLoad;
+        break;
+      default:
+    }
+  });
+
+export default itunesContainerReducer;

--- a/app/containers/ItunesContainer/saga.js
+++ b/app/containers/ItunesContainer/saga.js
@@ -1,0 +1,13 @@
+import { takeLatest } from 'redux-saga/effects';
+import { itunesContainerTypes } from './reducer';
+
+// Individual exports for testing
+const { DEFAULT_ACTION } = itunesContainerTypes;
+
+export function* defaultFunction(/* action */) {
+  // console.log('Do something here')
+}
+
+export default function* itunesContainerSaga() {
+  yield takeLatest(DEFAULT_ACTION, defaultFunction);
+}

--- a/app/containers/ItunesContainer/selectors.js
+++ b/app/containers/ItunesContainer/selectors.js
@@ -1,0 +1,12 @@
+import { createSelector } from 'reselect';
+import { initialState } from './reducer';
+
+/**
+ * Direct selector to the itunesContainer state domain
+ */
+
+const selectItunesContainerDomain = (state) => state.itunesContainer || initialState;
+
+export const selectItunesContainer = () => createSelector(selectItunesContainerDomain, (substate) => substate);
+
+export const selectSomePayLoad = () => createSelector(selectItunesContainerDomain, (substate) => substate.somePayLoad);

--- a/app/containers/ItunesContainer/tests/index.test.js
+++ b/app/containers/ItunesContainer/tests/index.test.js
@@ -1,0 +1,24 @@
+/**
+ *
+ * Tests for ItunesContainer container
+ *
+ *
+ */
+
+import React from 'react';
+// import { fireEvent } from '@testing-library/dom';
+import { renderProvider } from '@utils/testUtils';
+import { ItunesContainerTest as ItunesContainer } from '../index';
+
+describe('<ItunesContainer /> container tests', () => {
+  // let submitSpy
+
+  beforeEach(() => {
+    // submitSpy = jest.fn();
+  });
+
+  it('should render and match the snapshot', () => {
+    const { baseElement } = renderProvider(<ItunesContainer />);
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/app/containers/ItunesContainer/tests/reducer.test.js
+++ b/app/containers/ItunesContainer/tests/reducer.test.js
@@ -1,0 +1,17 @@
+import { itunesContainerReducer, itunesContainerTypes, initialState } from '../reducer';
+
+describe('ItunesContainer reducer tests', () => {
+  it('should return the initial state by default', () => {
+    expect(itunesContainerReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should return the updated state when an action of type DEFAULT is dispatched', () => {
+    const expectedResult = { ...initialState, somePayLoad: 'Mohammed Ali Chherawalla' };
+    expect(
+      itunesContainerReducer(initialState, {
+        type: itunesContainerTypes.DEFAULT_ACTION,
+        somePayLoad: 'Mohammed Ali Chherawalla'
+      })
+    ).toEqual(expectedResult);
+  });
+});

--- a/app/containers/ItunesContainer/tests/saga.test.js
+++ b/app/containers/ItunesContainer/tests/saga.test.js
@@ -1,0 +1,15 @@
+/**
+ * Test itunesContainer sagas
+ */
+
+import { takeLatest } from 'redux-saga/effects';
+import itunesContainerSaga, { defaultFunction } from '../saga';
+import { itunesContainerTypes } from '../reducer';
+
+describe('ItunesContainer saga tests', () => {
+  const generator = itunesContainerSaga();
+
+  it('should start task to watch for DEFAULT_ACTION action', () => {
+    expect(generator.next().value).toEqual(takeLatest(itunesContainerTypes.DEFAULT_ACTION, defaultFunction));
+  });
+});

--- a/app/containers/ItunesContainer/tests/selectors.test.js
+++ b/app/containers/ItunesContainer/tests/selectors.test.js
@@ -1,0 +1,19 @@
+import { selectItunesContainer, selectSomePayLoad } from '../selectors';
+
+describe('ItunesContainer selector tests', () => {
+  const mockedState = {
+    itunesContainer: {
+      somePayLoad: 'W.S'
+    }
+  };
+
+  it('should select the itunesContainer state', () => {
+    const itunesContainerSelector = selectItunesContainer();
+    expect(itunesContainerSelector(mockedState)).toEqual(mockedState.itunesContainer);
+  });
+
+  it('should select the somePayLoad state', () => {
+    const somePayLoadSelector = selectSomePayLoad();
+    expect(somePayLoadSelector(mockedState)).toEqual(mockedState.itunesContainer.somePayLoad);
+  });
+});

--- a/app/routeConfig.js
+++ b/app/routeConfig.js
@@ -1,10 +1,16 @@
 import NotFound from '@containers/NotFoundPage/Loadable';
 import HomeContainer from '@containers/HomeContainer/Loadable';
+import ItunesContainer from './containers/ItunesContainer/index';
 import routeConstants from '@utils/routeConstants';
 export const routeConfig = {
   repos: {
     component: HomeContainer,
     ...routeConstants.repos
+  },
+  itunes: {
+    component: ItunesContainer,
+    ...routeConstants.itune,
+    route: '/itunes'
   },
   notFoundPage: {
     component: NotFound,

--- a/app/utils/routeConstants.js
+++ b/app/utils/routeConstants.js
@@ -6,5 +6,9 @@ export default {
       padding: 20
     },
     exact: true
+  },
+  itunes: {
+    route: '/itunes',
+    exact: true
   }
 };


### PR DESCRIPTION

### Description
Added component and container where we can view the iTunes tracks mock values under '/itunes' route.

### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]
