### PR TITLE
fix: image loader support for M1 & M2 chips

### DIFF
--- a/internals/webpack/webpack.config.base.js
+++ b/internals/webpack/webpack.config.base.js
@@ -112,7 +112,7 @@ module.exports = (options) => ({
             }
           },
           {
-            loader: 'image-webpack-loader',
+            loader: 'img-loader',
             options: {
               mozjpeg: {
                 enabled: false

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "engines": {
     "npm": ">=5",
-    "node": ">=8.15.1"
+    "node": ">=8.15.1 <17.9.1"
   },
   "author": "Mac",
   "homepage": "http://wednesday-solutions.github.io/react-template",
@@ -193,8 +193,8 @@
     "gh-pages": "^3.2.3",
     "html-loader": "2.1.2",
     "html-webpack-plugin": "^5.5.0",
-    "image-webpack-loader": "^8.1.0",
     "http-server": "^14.1.1",
+    "img-loader": "4.0.0",
     "imports-loader": "3.0.0",
     "jest-cli": "27.0.5",
     "jest-coverage-badges": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12443,6 +12443,13 @@ image-ssim@^0.2.0:
   resolved "https://registry.yarnpkg.com/image-ssim/-/image-ssim-0.2.0.tgz#83b42c7a2e6e4b85505477fe6917f5dbc56420e5"
   integrity sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==
 
+img-loader@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/img-loader/-/img-loader-4.0.0.tgz#f41fb0737cc8e1d6a8c242f48c29a443640e0638"
+  integrity sha512-UwRcPQdwdOyEHyCxe1V9s9YFwInwEWCpoO+kJGfIqDrBDqA8jZUsEZTxQ0JteNPGw/Gupmwesk2OhLTcnw6tnQ==
+  dependencies:
+    loader-utils "^1.1.0"
+
 immer@9.0.3:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.3.tgz#146e2ba8b84d4b1b15378143c2345559915097f4"
@@ -15014,7 +15021,7 @@ loader-utils@0.2.x:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.2.3:
+loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.2.tgz#29a957f3a63973883eb684f10ffd3d151fec01a3"
   integrity sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==


### PR DESCRIPTION
### Ticket Link

---

### Related Links

---

### Description
fixed image loader support for M1 & M2 chips
---

### Steps to Reproduce / Test

---

---

### Checklist

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

### GIF's

---

### Live Link

---

- http://wednesday-react-template.s3-website.ap-south-1.amazonaws.com/<BRANCH_NAME>
