### PR TITLE
fix/optipng module issue on armx64

### DIFF
--- a/internals/webpack/webpack.config.base.js
+++ b/internals/webpack/webpack.config.base.js
@@ -135,7 +135,11 @@ module.exports = (options) => ({
                 interlaced: false
               },
               optipng: {
-                optimizationLevel: 7
+                enabled: false
+                // NOTE: optipng is disabled as it causes errors in some Mac M1 & M2 environments
+                // Try enabling it in your environment by switching the config to:
+                // enabled: true,
+                // optimizationLevel: 7
               },
               pngquant: {
                 quality: [0.65, 0.9],


### PR DESCRIPTION
### Ticket Link

---

### Related Links

---

### Description
optipng-bin module not found error on M1 & M2 armx64
---

### Steps to Reproduce / Test
1. Clone the repo in M1 armx64 (Check if you've armx64 by node -p "process.arch")
2. yarn install (Even tho everything will get successful you'll see some warning error from optipng )
3. yarn start (Error from optipng-bin or pngbinquant will occur. Refer to ss below)
4. Try fixing the error by adding that module
5. You'll still get the error from import of png file logo in Header component (Refer ss below. Also try commenting it out to verify this)
<img width="856" alt="Screenshot 2024-03-06 at 11 20 12 AM" src="https://github.com/wednesday-solutions/react-template/assets/161311819/8e553014-322f-4744-8cec-d8d3f732e47c">
<img width="864" alt="Screenshot 2024-03-06 at 11 21 29 AM" src="https://github.com/wednesday-solutions/react-template/assets/161311819/18f200d2-de41-4d41-918f-3144f5ac4895">

---

---

### Checklist

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

### GIF's

---

### Live Link

---

- http://wednesday-react-template.s3-website.ap-south-1.amazonaws.com/<BRANCH_NAME>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Disabled `optipng` optimization by default to prevent errors on Mac M1 & M2 environments. Users can manually enable it if desired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->