### PR TITLE
feat: replace apisauce with wretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ An enterprise react template application showcasing - Testing strategies, Global
   - [app/containers/HomeContainer/saga.js](app/containers/HomeContainer/saga.js)
   - [app/containers/HomeContainer/index.js](app/containers/HomeContainer/index.js)
 
-## Network requests using apisauce
+## Network requests using wretch
 
-- API calls using [Api Sauce](https://github.com/infinitered/apisauce/)
+- API calls using [Wretch](https://github.com/elbywan/wretch)
 
   Take a look at the following files
 

--- a/app/services/repoApi.js
+++ b/app/services/repoApi.js
@@ -1,4 +1,4 @@
 import { generateApiClient } from '@utils/apiUtils';
 const repoApi = generateApiClient('github');
 
-export const getRepos = (repoName) => repoApi.get(`/search/repositories?q=${repoName}`);
+export const getRepos = (repoName) => repoApi.get(`search/repositories?q=${repoName}`);

--- a/app/services/tests/repoApi.test.js
+++ b/app/services/tests/repoApi.test.js
@@ -1,18 +1,20 @@
-import MockAdapter from 'axios-mock-adapter';
-import { getApiClient } from '@utils/apiUtils';
 import { getRepos } from '../repoApi';
 
 describe('RepoApi tests', () => {
   const repositoryName = 'mac';
+
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+
   it('should make the api call to "/search/repositories?q="', async () => {
-    const mock = new MockAdapter(getApiClient().axiosInstance);
-    const data = [
-      {
-        totalCount: 1,
-        items: [{ repositoryName }]
-      }
-    ];
-    mock.onGet(`/search/repositories?q=${repositoryName}`).reply(200, data);
+    const data = {
+      totalCount: 1,
+      items: [{ repositoryName }]
+    };
+
+    fetch.mockResponseOnce(JSON.stringify(data), { status: 200 });
+
     const res = await getRepos(repositoryName);
     expect(res.data).toEqual(data);
   });

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,8 @@
 import '@testing-library/jest-dom';
+import { enableMocks } from 'jest-fetch-mock';
+
+// jest.setup.js
+enableMocks();
 
 jest.mock('react-router-dom', () => {
   const originalModule = jest.requireActual('react-router-dom');

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "@mui/material": "^5.11.5",
     "@mui/styled-engine": "^5.11.0",
     "@mui/styled-engine-sc": "^5.11.0",
-    "apisauce": "2.1.1",
     "chalk": "4.1.1",
     "compression": "1.7.4",
     "cross-env": "7.0.3",
@@ -126,7 +125,8 @@
     "redux-saga": "1.1.3",
     "reduxsauce": "^1.1.0",
     "reselect": "4.0.0",
-    "sanitize.css": "8.0.0"
+    "sanitize.css": "8.0.0",
+    "wretch": "^2.9.0"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.54.0",
@@ -166,7 +166,6 @@
     "@testing-library/react": "^13.3.0",
     "add-asset-html-webpack-plugin": "^5.0.2",
     "axe-playwright": "^1.1.12",
-    "axios-mock-adapter": "^1.17.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.1.0",
     "babel-loader": "^8.2.2",
@@ -216,6 +215,7 @@
     "imports-loader": "3.0.0",
     "jest-cli": "27.0.5",
     "jest-coverage-badges": "^1.1.2",
+    "jest-fetch-mock": "^3.0.3",
     "jest-sonar": "^0.2.12",
     "less": "^4.1.1",
     "less-loader": "7.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6167,14 +6167,6 @@ anymatch@^3.0.0, anymatch@^3.0.3, anymatch@~3.1.1, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apisauce@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/apisauce/-/apisauce-2.1.1.tgz#0b8bc7f2544e6ef710a6fa1d6f49583856940dd2"
-  integrity sha512-P4SsLvmsH8BLLruBn/nsO+65j+ChZlGQ2zC5avCIjbWstYS4PgjxeVWtbeVwFGEWX7dEkLp85OvdapGXy1zS8g==
-  dependencies:
-    axios "^0.21.1"
-    ramda "^0.25.0"
-
 app-root-dir@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/app-root-dir/-/app-root-dir-1.0.2.tgz#38187ec2dea7577fff033ffcb12172692ff6e118"
@@ -6618,14 +6610,6 @@ axe-playwright@^1.1.12:
     axe-core "^4.5.1"
     axe-html-reporter "2.2.3"
     picocolors "^1.0.0"
-
-axios-mock-adapter@^1.17.0:
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.22.0.tgz#0f3e6be0fc9b55baab06f2d49c0b71157e7c053d"
-  integrity sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    is-buffer "^2.0.5"
 
 axios@^0.21.1:
   version "0.21.4"
@@ -8576,6 +8560,13 @@ cross-env@7.0.3:
   integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
   dependencies:
     cross-spawn "^7.0.1"
+
+cross-fetch@^3.0.4:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -13156,7 +13147,7 @@ is-buffer@^1.1.5, is-buffer@~1.1.6:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.0, is-buffer@^2.0.5:
+is-buffer@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
@@ -14135,6 +14126,14 @@ jest-environment-node@^28.0.0, jest-environment-node@^28.1.3:
     "@types/node" "*"
     jest-mock "^28.1.3"
     jest-util "^28.1.3"
+
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
 
 jest-get-type@^26.3.0:
   version "26.3.0"
@@ -16452,7 +16451,7 @@ node-dir@^0.1.10:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@^2, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@^2, node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -18234,6 +18233,11 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==
 
+promise-polyfill@^8.1.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
+  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
+
 promise.allsettled@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/promise.allsettled/-/promise.allsettled-1.0.7.tgz#b9dd51e9cffe496243f5271515652c468865f2d8"
@@ -18442,11 +18446,6 @@ quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
-
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
-  integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
 
 ramda@^0.27.1:
   version "0.27.2"
@@ -22642,6 +22641,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+wretch@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/wretch/-/wretch-2.9.0.tgz#0c36621be2d407a1725791f318ecf6d9bb267c48"
+  integrity sha512-kKp1xWQO+Vh9I6RJq7Yers2KKrmF7LXB00c9knMDn3IdB7etcQOarrsHArpj1sZ1Dlav8ss6R1DuUpDSTqmQew==
 
 write-file-atomic@^2.0.0:
   version "2.4.3"


### PR DESCRIPTION
### Ticket Link

---

### Related Links

---

### Description

1. Replaced Apisauce(axios) with Wretch
2. Added support for wretch in tests

#### Reason to migrate from apisauce to wretch
Reduce bundle size

#### With apisauce
<img width="1434" alt="Screenshot 2024-07-16 at 4 02 37 PM" src="https://github.com/user-attachments/assets/99ef8339-b11d-4e12-81da-e338231d83ab">

#### With Wretch
<img width="1421" alt="Screenshot 2024-07-16 at 4 04 06 PM" src="https://github.com/user-attachments/assets/b15c7295-33e8-4d39-b034-f4842eb0422d">

---

### Steps to Reproduce / Test

---

---

### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added]
- [x] Relevant documentation is changed or added (and PR referenced)

### GIF's

---

### Live Link

---

- http://wednesday-react-template.s3-website.ap-south-1.amazonaws.com/feat/wretch-setup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Switched from `Api Sauce` to `Wretch` for API calls, enhancing network request handling.

- **Bug Fixes**
  - Updated string interpolation in API URL construction to use backticks for consistency.

- **Tests**
  - Replaced Axios mock with fetch mock in API call tests for more accurate simulation of API responses.

- **Chores**
  - Updated dependencies: removed `apisauce` and `axios-mock-adapter`, added `wretch` and `jest-fetch-mock`.
  - Enabled `jest-fetch-mock` for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->