### PR TITLE
chore: add proper body transformation to sneak case with wretch

### DIFF
--- a/app/services/repoApi.js
+++ b/app/services/repoApi.js
@@ -1,4 +1,7 @@
 import { generateApiClient } from '@utils/apiUtils';
 const repoApi = generateApiClient('github');
 
+/**
+ * @see https://github.com/elbywan/wretch?tab=readme-ov-file#http-methods-
+ */
 export const getRepos = (repoName) => repoApi.get(`search/repositories?q=${repoName}`);

--- a/app/utils/apiUtils.js
+++ b/app/utils/apiUtils.js
@@ -61,9 +61,9 @@ export const createApiClientWithTransForm = (baseURL) => {
     const { body } = opts;
     if (body) {
       // this needs to actually mutate the request
-      // eslint-disable-next-line immutable/no-mutation
       try {
         const parsedBody = JSON.parse(body);
+        // eslint-disable-next-line immutable/no-mutation
         opts.body = JSON.stringify(mapKeysDeep(parsedBody, (keys) => snakeCase(keys)));
       } catch (error) {
         console.error('Invalid JSON body:', error);

--- a/app/utils/apiUtils.js
+++ b/app/utils/apiUtils.js
@@ -62,7 +62,7 @@ export const createApiClientWithTransForm = (baseURL) => {
     if (body) {
       // this needs to actually mutate the request
       // eslint-disable-next-line immutable/no-mutation
-      opts.body = mapKeysDeep(body, (keys) => snakeCase(keys));
+      opts.body = JSON.stringify(mapKeysDeep(JSON.parse(body), (keys) => snakeCase(keys)));
     }
     return next(url, opts);
   };

--- a/app/utils/apiUtils.js
+++ b/app/utils/apiUtils.js
@@ -62,7 +62,13 @@ export const createApiClientWithTransForm = (baseURL) => {
     if (body) {
       // this needs to actually mutate the request
       // eslint-disable-next-line immutable/no-mutation
-      opts.body = JSON.stringify(mapKeysDeep(JSON.parse(body), (keys) => snakeCase(keys)));
+      try {
+        const parsedBody = JSON.parse(body);
+        opts.body = JSON.stringify(mapKeysDeep(parsedBody, (keys) => snakeCase(keys)));
+      } catch (error) {
+        console.error('Invalid JSON body:', error);
+        throw new Error('Invalid JSON body');
+      }
     }
     return next(url, opts);
   };


### PR DESCRIPTION
### Ticket Link

---

### Related Links

---

### Description
- Handle body transformation to sneak case.
- Body needs to be in JSON to send it with POST request.
- In case of apiSauce it was converting to json after we convert body to sneakCase. It's not the same in case of Wretch.
- So in wretch we have to first parse it to make it sneakCase and than strigify it send payload with request.
---

### Steps to Reproduce / Test
- Try POST request and see the payload. It's not transforming to sneakCase.
---

---

### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

### GIF's

---

### Live Link

---

- http://wednesday-react-template.s3-website.ap-south-1.amazonaws.com/<BRANCH_NAME>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added documentation comments for the `getRepos` function to improve understanding of its usage.

- **New Features**
	- Enhanced the `createApiClientWithTransForm` function to robustly handle and transform JSON request bodies, improving error handling and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->